### PR TITLE
added the functions setting node_bundler esbuild to the netlify.toml …

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,9 @@
   functions = "netlify/functions"
   publish = "public"
 
+[functions]
+  node_bundler = "esbuild" 
+
   ## Uncomment to use this redirect for Single Page Applications like create-react-app.
   ## Not needed for static site generators.
   #[[redirects]]


### PR DESCRIPTION
…for the deployment

I missed this the first time through since it was working locally, when I tried to deploy I realized I needed the `node_bundler="esbuild"` for the functions.